### PR TITLE
test registration via access/authorize

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,3 +31,4 @@ jobs:
     - run: npm test
       env:
         REGISTERED_SPACE_SIGNER: ${{ secrets.REGISTERED_SPACE_SIGNER }}
+        W3S_EMAIL: ${{ vars.W3S_EMAIL }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,3 +29,5 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+      env:
+        REGISTERED_SPACE_SIGNER: ${{ secrets.REGISTERED_SPACE_SIGNER }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    environment: staging
     strategy:
       matrix:
         node-version: [18.x]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+/.env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ucanto/client": "^4.0.3",
         "@ucanto/core": "^4.0.3",
         "@ucanto/interface": "^4.0.3",
-        "@ucanto/principal": "^4.0.3",
+        "@ucanto/principal": "^4.2.3",
         "@ucanto/transport": "^4.0.3",
         "@web3-storage/capabilities": "^2.3.0",
         "@web3-storage/upload-client": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "node --test dist"
+    "test": "node --test dist",
+    "pretest:only": "npm run pretest",
+    "test:only": "node --test --test-only dist"
   },
   "author": "",
   "license": "ISC",
@@ -21,7 +23,7 @@
     "@ucanto/client": "^4.0.3",
     "@ucanto/core": "^4.0.3",
     "@ucanto/interface": "^4.0.3",
-    "@ucanto/principal": "^4.0.3",
+    "@ucanto/principal": "^4.2.3",
     "@ucanto/transport": "^4.0.3",
     "@web3-storage/capabilities": "^2.3.0",
     "@web3-storage/upload-client": "^5.3.0"

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -344,7 +344,7 @@ class DidMailto {
   }
 }
 
-test('can invoke access/authorize against staging', async () => {
+test('can invoke access/authorize against staging', { skip: true }, async () => {
   const w3 = w3s().staging;
   const issuer = await ed25519.generate();
   const authorizeAsEmail = await readEmailAddressFromEnv(process.env, 'W3S_EMAIL');

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -363,7 +363,7 @@ test('can invoke access/authorize against staging', { skip: true }, async () => 
 
 test('can use registered space', { only: true }, async () => {
   const w3 = w3s().staging;
-  console.warn('Object.keys(process.env)', Object.keys(process.env))
+  console.warn('Object.keys(process.env)', JSON.stringify(Object.keys(process.env).sort()))
   console.warn(`'REGISTERED_SPACE_SIGNER' in process.env`, 'REGISTERED_SPACE_SIGNER' in process.env)
   const registeredSpace = await readSignerFromEnv(process.env, 'REGISTERED_SPACE_SIGNER')
   const delegate = Access.delegate.invoke({

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -363,8 +363,6 @@ test('can invoke access/authorize against staging', { skip: true }, async () => 
 
 test('can use registered space', { only: true }, async () => {
   const w3 = w3s().staging;
-  console.warn('Object.keys(process.env)', JSON.stringify(Object.keys(process.env).sort()))
-  console.warn(`'REGISTERED_SPACE_SIGNER' in process.env`, 'REGISTERED_SPACE_SIGNER' in process.env)
   const registeredSpace = await readSignerFromEnv(process.env, 'REGISTERED_SPACE_SIGNER')
   const delegate = Access.delegate.invoke({
     issuer: registeredSpace,

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -330,6 +330,21 @@ test('can invoke access/delegate', async () => {
   // assert.notDeepEqual(result.error, true, 'access/delegate result is not an error')
 })
 
+test('can invoke access/claim', async () => {
+  const w3 = w3s().staging;
+  const issuer = await ed25519.generate();
+  const delegate = await Access.claim.invoke({
+      issuer,
+      audience: w3.id,
+      with: issuer.did(),
+      proofs: []
+    }).delegate()
+  const [result] = await w3.execute(delegate);
+  warnIfError(result)
+  assert.notDeepEqual(result.error, true, 'access/delegate result is not an error')
+})
+
+
 function warnIfError(result: Ucanto.Result<unknown, { error: true }>) {
   if ('error' in result) {
     console.warn('error result', result)

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -363,6 +363,7 @@ test('can invoke access/authorize against staging', { skip: true }, async () => 
 
 test('can use registered space', { only: true }, async () => {
   const w3 = w3s().staging;
+  console.warn('Object.keys(process.env)', Object.keys(process.env))
   console.warn(`'REGISTERED_SPACE_SIGNER' in process.env`, 'REGISTERED_SPACE_SIGNER' in process.env)
   const registeredSpace = await readSignerFromEnv(process.env, 'REGISTERED_SPACE_SIGNER')
   const delegate = Access.delegate.invoke({

--- a/src/w3protocol.test.ts
+++ b/src/w3protocol.test.ts
@@ -406,6 +406,9 @@ test('can use registered space', { only: true }, async () => {
   }
 })
 
+/**
+ * attempt to register a space via voucher/claim invocation
+ */
 async function registerSpaceViaVoucherClaim(
   registeredSpace: ed25519.Signer.EdSigner,
   connection: Ucanto.ConnectionView<Record<string,any>>,
@@ -425,6 +428,9 @@ async function registerSpaceViaVoucherClaim(
   throw new Error(`click link in email ${email.toString()} to register space ${registeredSpace.did()} using voucher`)
 }
 
+/**
+ * attempt to register a space via access/authorize invocation
+ */
 async function registerSpaceViaAccessAuthorize(
   registeredSpace: ed25519.Signer.EdSigner,
   connection: Ucanto.ConnectionView<Record<string,any>>,


### PR DESCRIPTION
Motivation:
* test https://github.com/web3-storage/w3protocol/pull/392

Insights:
* This test tries to register the space by invoking access/authorize with email address from env var. In practice, I used my email address, clicked the link, and retried, but that doesn't work. I think that's a sign `access/authorize` doesn't currently register the space in a way that matches [my check](https://github.com/web3-storage/w3protocol/blob/4f0bd1c1cd3cfb1c848892ad418c6d7b2197045a/packages/access-api/src/service/index.js#L37)
  * I can adjust my check and/or we can make it so clicking the email sent via `access/authorize` writes into the `delegations` table in a way my check would pass